### PR TITLE
Properly use EVAL-WHEN to compile with Bazel

### DIFF
--- a/cl-json.asd
+++ b/cl-json.asd
@@ -4,10 +4,8 @@
 ;;; All rights reserved.
 ;;; See the file LICENSE for terms of use and distribution.
 
-(in-package #:cl-user)
-
 (defpackage #:json-system
-    (:use #:cl #:asdf))
+  (:use :cl :asdf :uiop))
 
 (in-package #:json-system)
 
@@ -24,9 +22,8 @@
   :version "0.5.0"
   :maintainer "Henrik Hjelte <henrik@henrikhjelte.com>"
   :licence "MIT"
-  :in-order-to ((test-op (test-op "cl-json.test")))
-  :components ((:static-file "cl-json.asd")
-               (:module :src
+  :in-order-to ((test-op (test-op "cl-json/test")))
+  :components ((:module "src"
                 :components ((:file "package")
                              (:file "common" :depends-on ("package"))
                              #+cl-json-clos
@@ -37,20 +34,17 @@
                              (:file "utils" :depends-on ("decoder" "encoder"))
                              (:file "json-rpc" :depends-on ("package" "common" "utils" "encoder" "decoder"))))))
 
-(defsystem :cl-json.test
-  :depends-on (:cl-json :fiveam )
-  ;; newer ASDF versions have this implicitly, but I know of no good way to detect this. [2010/01/02:rpg]
-  :in-order-to ((test-op (load-op "cl-json.test")))
-  :components ((:module :t
-               :components ((:file "package")
-                            (:file "testmisc" :depends-on ("package" "testdecoder" "testencoder"))
-                            (:file "testdecoder" :depends-on ("package"))
-                            (:file "testencoder" :depends-on ("package"))))))
-
-(defmethod perform ((op test-op) (c (eql (find-system :cl-json.test))))
-  (funcall (intern (symbol-name '#:run!) :it.bese.FiveAM)
-           (intern (symbol-name '#:json) :json-test)))
+(defsystem "cl-json/test"
+  :depends-on ("cl-json" "fiveam")
+  :components ((:module "t"
+                :components ((:file "package")
+                             (:file "testmisc" :depends-on ("package" "testdecoder" "testencoder"))
+                             (:file "testdecoder" :depends-on ("package"))
+                             (:file "testencoder" :depends-on ("package")))))
+  :perform (test-op (o c)
+             (symbol-call :it.bese.FiveAM :run! (find-symbol* :json :json-test))))
 
 (defparameter *cl-json-directory*
-  (make-pathname :directory (pathname-directory *load-truename*)))
+  (pathname-directory-pathname (current-lisp-file-pathname)))
+
 

--- a/src/common.lisp
+++ b/src/common.lisp
@@ -10,7 +10,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -44,7 +44,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/decoder-args.lisp
+++ b/src/decoder-args.lisp
@@ -2,7 +2,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -21,7 +21,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -390,7 +390,7 @@ characters in string S to STREAM."
             (destructuring-bind (esc . (width . radix)) special
               (format stream "\\~C~V,V,'0R" esc radix width code)))))
 
-(eval-when (:compile-toplevel)
+(eval-when (:compile-toplevel :execute)
     (if (subtypep 'long-float 'single-float)
         ;; only one float type
         (pushnew :cl-json-only-one-float-type *features*)

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -53,12 +53,13 @@ registered in the superclass."
   (declare (ignore superclass subclass))
   (values))
 
-(defmethod validate-superclass ((class fluid-class)
-                                (superclass standard-class))
-  "Any fluid class is also a standard class."
-  t)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+ (defmethod validate-superclass ((class fluid-class)
+                                 (superclass standard-class))
+   "Any fluid class is also a standard class."
+   t))
 
-(finalize-inheritance
+(eval-when (:compile-toplevel :load-toplevel :execute)
  (defclass fluid-object (standard-object) ()
    (:documentation "Any instance of a fluid class.")
    (:metaclass fluid-class)))

--- a/t/testdecoder.lisp
+++ b/t/testdecoder.lisp
@@ -267,7 +267,7 @@ safe-symbols-parsing function here for a cure."
 
 
 (defparameter *json-test-files-path*
-  (asdf:system-relative-pathname "cl-json.test" "t/"))
+  (asdf:system-relative-pathname "cl-json/test" "t/"))
 
 (defun test-file (name)
   (make-pathname :name name :type "json" :defaults *json-test-files-path*))


### PR DESCRIPTION
1- EVAL-WHEN needs to always include :execute
   See the discussion at http://fare.livejournal.com/146698.html
2- Use EVAL-WHEN around some key metaclass definitions.