### PR TITLE
Surrogate pair encoding char-codes #x10000-#x1FFFF

### DIFF
--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -387,9 +387,9 @@ characters in string S to STREAM."
        do (write-char ch stream)
      else if (< #x10000 code #x1FFFF)
        do (let ((c (- code #x10000)))
-            (format stream "~C~C"
-                    (code-char (logior #xd800 (ash c -10)))
-                    (code-char (logior #xdc00 (logand c #x3ff)))))
+            (format stream "\\u~x\\u~x"
+                    (logior #xd800 (ash c -10))
+                    (logior #xdc00 (logand c #x3ff))))
      else
        do (let ((special '#.(rassoc-if #'consp +json-lisp-escaped-chars+)))
             (destructuring-bind (esc . (width . radix)) special

--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -385,6 +385,11 @@ characters in string S to STREAM."
        do (write-char #\\ stream) (write-char special stream)
      else if (< #x1f code #x7f)
        do (write-char ch stream)
+     else if (< #x10000 code #x1FFFF)
+       do (let ((c (- code #x10000)))
+            (format stream "~C~C"
+                    (code-char (logior #xd800 (ash c -10)))
+                    (code-char (logior #xdc00 (logand c #x3ff)))))
      else
        do (let ((special '#.(rassoc-if #'consp +json-lisp-escaped-chars+)))
             (destructuring-bind (esc . (width . radix)) special


### PR DESCRIPTION
Original description:

According to the documentation found in the net [1], characters outside basic multilingual plane should be encoded using surrogate pairs.

This is minimally tested, but works on my use case where I need to feed EMOJI to a mobile client and my users were getting garbage displayed to them.

Optimally, the decoding side should probably be hacked to be able to do the reverse as well. I don't have need for this at the moment so haven't looked into it yet.

[1] http://www.ietf.org/rfc/rfc4627.txt "2.5 Strings"