### PR TITLE
Properly use EVAL-WHEN to compile with Bazel

### DIFF
--- a/cl-json.asd
+++ b/cl-json.asd
@@ -4,10 +4,8 @@
 ;;; All rights reserved.
 ;;; See the file LICENSE for terms of use and distribution.
 
-(in-package #:cl-user)
-
 (defpackage #:json-system
-    (:use #:cl #:asdf))
+  (:use :cl :asdf :uiop))
 
 (in-package #:json-system)
 
@@ -26,8 +24,7 @@
   :maintainer "Robert P. Goldman <rpgoldman@sift.net>"
   :licence "MIT"
   :in-order-to ((test-op (test-op "cl-json/test")))
-  :components ((:static-file "cl-json.asd")
-               (:module :src
+  :components ((:module "src"
                 :components ((:file "package")
                              (:file "common" :depends-on ("package"))
                              #+cl-json-clos
@@ -52,4 +49,5 @@
 
 (defparameter *cl-json-directory*
   (system-relative-pathname "cl-json" ""))
+
 

--- a/src/common.lisp
+++ b/src/common.lisp
@@ -11,7 +11,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -45,7 +45,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/decoder-args.lisp
+++ b/src/decoder-args.lisp
@@ -3,7 +3,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -22,7 +22,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -391,7 +391,7 @@ characters in string S to STREAM."
             (destructuring-bind (esc . (width . radix)) special
               (format stream "\\~C~V,V,'0R" esc radix width code)))))
 
-(eval-when (:compile-toplevel)
+(eval-when (:compile-toplevel :execute)
     (if (subtypep 'long-float 'single-float)
         ;; only one float type
         (pushnew :cl-json-only-one-float-type *features*)

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -54,12 +54,13 @@ registered in the superclass."
   (declare (ignore superclass subclass))
   (values))
 
-(defmethod validate-superclass ((class fluid-class)
-                                (superclass standard-class))
-  "Any fluid class is also a standard class."
-  t)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+ (defmethod validate-superclass ((class fluid-class)
+                                 (superclass standard-class))
+   "Any fluid class is also a standard class."
+   t))
 
-(finalize-inheritance
+(eval-when (:compile-toplevel :load-toplevel :execute)
  (defclass fluid-object (standard-object) ()
    (:documentation "Any instance of a fluid class.")
    (:metaclass fluid-class)))


### PR DESCRIPTION
1- EVAL-WHEN needs to always include :execute
   See the discussion at http://fare.livejournal.com/146698.html
2- Use EVAL-WHEN around some key metaclass definitions.

Replaces #4 which it just rebases.