### PR TITLE
Finalizing inheritance for fluid-object

### DIFF
--- a/src/decoder.lisp
+++ b/src/decoder.lisp
@@ -103,7 +103,7 @@ as a string."
         (read-part Int nil #\-)
         (read-part Frac #\.)
         (read-part Exp #\e #\- #\+)
-        (if c (unread-char c stream))
+	(when c (unread-char c stream))
         (values category (coerce (cdr chars) 'string))))))
 
 (defun read-json-name-token (stream)

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -63,7 +63,8 @@ registered in the superclass."
 (eval-when (:compile-toplevel :load-toplevel :execute)
  (defclass fluid-object (standard-object) ()
    (:documentation "Any instance of a fluid class.")
-   (:metaclass fluid-class)))
+   (:metaclass fluid-class))
+ (finalize-inheritance (find-class 'fluid-object)))
 
 (defmethod compute-class-precedence-list ((class fluid-class))
   "Objects of fluid classes are fluid objects."


### PR DESCRIPTION
Fixes an error where the first time the fluid-object is being instantiated - its class inheritance is not yet finalized.
Affects cases where a the `with-decoder-simple-clos-semantics` is used without an explicit class (a default fluid-object class is used).

Fixes 4 of the test cases:
```
TEST-ENCODE-JSON-CLOS-MAX-PACKAGE in JSON []:
TEST-ENCODE-JSON-CLOS in JSON []:
JSON-OBJECT-WITH-PROTOTYPE in JSON []:
JSON-OBJECT in JSON []:
```

I've only tested this with SBCL so far.
Haven't tested it in too much effort yet, but as far as i understand - when new classes/slots would appear - the class would go through reinitialization anyways, so I'm not expecting this to have negative effects.
(not an expert though :) )