### PR TITLE
if=>when to unread number token symbols

### DIFF
--- a/src/decoder.lisp
+++ b/src/decoder.lisp
@@ -103,7 +103,7 @@ as a string."
         (read-part Int nil #\-)
         (read-part Frac #\.)
         (read-part Exp #\e #\- #\+)
-        (if c (unread-char c stream))
+	(when c (unread-char c stream))
         (values category (coerce (cdr chars) 'string))))))
 
 (defun read-json-name-token (stream)


### PR DESCRIPTION
Replacing "if" with "when" during "read-json-number-token"

This was causing issues in SBCL when spamming the stream - seemingly since the unread-char would break the stream sequence.

The issue still persists, but it was possible to spam the stream a lot more before breaking (in my case it's a unix socket connected stream).

This is honestly rather dumb, and feels like SBCL is doing something weird in case of "if" (since "when" should technically still macroexpand to if), but since based on CL spec - this should be of no difference, i'm just going to leave this here.